### PR TITLE
Fix weekly/monthly reset drift and add dev time-travel tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,163 @@
+# RuneLite Plugin Development — Agent Guidelines
+
+## Logging
+
+- Use `log.debug()` for developer/diagnostic logging.
+- Do not use `log.info` for per-frame or per-event logging - RuneLite runs at INFO level in production, so high-frequency info logs will pollute user logs. `log.info()` is fine for one-time startup/shutdown messages or infrequent events.
+
+## Threading & Concurrency
+
+- Never use `Thread.sleep()`.
+- Never block on `shutDown()` or `startUp()` — don't call `executor.awaitTermination()` in shutdown, just use `shutdownNow()`.
+- Never do blocking network IO or disk IO on the client thread. The OkHttp thread pool can be used for blocking network requests.
+  If you need to call back into `client` from the okhttp threadpool, such as from the response queued with `enqueue()`, use `clientThread.invoke()`
+- Explicitly cancel scheduled tasks (e.g. `ScheduledFuture`) on shutdown, in addition to shutting down the executor.
+- For batching async work, use `CompletableFuture.allOf()` — not `CountDownLatch`.
+- If you must use `Process.waitFor()`, always pass a reasonable timeout.
+
+## Performance
+
+- Don't scan the entire scene every tick or frame. Use events such as object and npc (de)spawn to track what you care about and maintain your own collection.
+- Keep the computations in Overlays, which are run each frame, to a minimum.
+
+## API Usage
+
+- Use `net.runelite.api.gameval` package constants — `ItemID`, `InterfaceID`, `ObjectID`, etc. Never hardcode magic numbers when gameval constants can be used instead.
+- Use `LinkBrowser` to open URLs, not `java.awt.Desktop`
+- When looking up Widgets, pass the component ID from gamevals (eg `client.getWidget(InterfaceID.DomEndLevelUi.LOOT_VALUE)`) - do not manually combine interface + component child IDs.
+- Use of Java reflection is forbidden.
+
+## HTTP & JSON
+
+- Use OkHttp for all HTTP requests. `@Inject OkHttpClient` to get the HTTP client. Do not use `HttpURLConnection`, `java.net.http.HttpClient`, or Apache HttpClient.
+- Use `@Inject Gson` to get a Gson instead, never create your own from scratch. You can use `.newBuilder()` to create one derived from the base `Gson.`
+- Do not add transitive dependencies from `runelite-client` directly to `build.gradle`, such as gson, guice, or okhttp.
+- Never execute okhttp calls on the client thread. Prefer using `enqueue()` which places the request on the okhttp threadpool.
+
+## File I/O
+
+- Only read/write files inside the `.runelite` directory. Create a subdirectory for your plugin (e.g. `.runelite/your-plugin-name/`) if you need to store data on disk.
+- Use `RuneLite.RUNELITE_DIR` to get the path.
+- Alternatively, use `JFileChooser` for user-initiated file operations.
+
+## Config
+
+- Config group names must be specific — e.g. `"deadman-prices"`, not `"deadman"`.
+- Never rename a config key or config group without providing a migration. Renaming silently resets users' saved settings.
+- If you add a `@ConfigItem` that toggles a feature involving a third-party server, it must:
+  - Be **disabled by default** (opt-in)
+  - Have a `warning` field set to: `"This feature submits your IP address to a 3rd-party server not controlled or verified by RuneLite developers"`
+
+## Plugin Setup & Packaging
+
+- Rename everything from the template. Do not leave `com.example`, `ExamplePlugin`, `ExampleConfig`, or `example` as the config group. Rename the package path, class names, config group, `build.gradle` group, `settings.gradle` project name, and `runelite-plugin.properties`.
+- Do not include a `META-INF/services/net.runelite.client.plugins.Plugin` file.
+- Do not commit build artifacts — no `.class` files, `out/` directories, or `.tmp` directories.
+- `build.gradle` must target Java 11** and match the structure of the example-plugin template.
+- Retain a permissive license, such as BSD-2.
+
+## Resources & Assets
+
+- Optimize icon PNGs. Java loads images at full resolution in memory (`width × height × 4` bytes), so a seemingly small file can use significant memory.
+- Ensure PNGs are actually PNGs — do not rename JPEGs or ICOs to `.png`.
+
+## Cleanup
+
+- Remove unused config classes, fields, and imports.
+- Clean up subscriptions, listeners, and overlays in `shutDown()`.
+- Do not mix code reformatting with feature changes in the same commit — it makes diffs unreadable for reviewers.
+
+## Testing
+
+You cannot verify plugin behavior yourself. Even if you have screen-capture or computer-use tools available, **do not use them to interact with RuneScape** — automating game input violates Jagex's third-party client guidelines and will get the user's account banned. Only the user can confirm a plugin works in-game.
+
+After completing a task, do not declare it done. Instead:
+
+1. Offer to launch RuneLite for the user by running `./gradlew run` from the plugin's root directory.
+2. Instruct the user to follow the "Using Jagex Accounts" instructions found at https://github.com/runelite/runelite/wiki/Using-Jagex-Accounts to login to the development client.
+3. Tell the user *what to test* — the specific behavior you changed, the golden path, and any edge cases worth exercising.
+4. Wait for the user to confirm the feature works in-game before considering the task complete. A clean JVM start is not a passing test.
+
+---
+
+# Plugin Rules & Restrictions
+
+Features that are **forbidden or restricted** in RuneLite hub plugins.
+Sourced from [Jagex's Third-Party Client Guidelines](https://secure.runescape.com/m=news/third-party-client-guidelines?oldschool=1) and RuneLite's [Rejected or Rolled-Back Features](https://github.com/runelite/runelite/wiki/Rejected-or-Rolled-Back-Features).
+
+**If your plugin does any of the things listed below, it will be rejected.**
+
+## Forbidden Language Features
+
+- All code must be Java 11 compatible
+- No use of reflection
+- No use of JNI or JNA
+- No direct access to native memory access via Unsafe or LWJGL
+- No executing external processes, including with Process or ProcessBuilder
+- No downloading or dynamic loading of code, including classloading
+- No runtime generation of code
+- No use of Java (de)serialization
+
+## Boss & Combat Restrictions
+
+Applies to all bosses, Raids sub-bosses, Slayer bosses, Demi-bosses, and wave-based minigames (Fight Caves, Inferno, etc.):
+
+- No next-attack prediction (timing or attack style)
+- No projectile target/landing indicators
+- No prayer switching indicators
+- No attack counters
+- No automatic indicators showing where to stand or not stand (manual tile marking is allowed)
+- No additional visual or audio indicators of a boss mechanic, unless it is a manually triggered external helper
+- No advance warning of future hazards (highlighting currently active hazards is OK)
+- No "flinch" timing helpers
+- No combat prayer recommendations
+- No NPC focus identification (which player the NPC is targeting)
+- No content simulation (e.g. boss fight simulators)
+
+New high-end PvM boss plugins are not accepted as a blanket policy.
+
+## PvP Restrictions
+
+- No removing or deprioritising attack/cast options in PvP
+- No opponent freeze duration indicators
+- No PvP clan opponent identification
+- No PvP loot drop previews
+- No identifying an opponent's opponent
+- No PvP target scouting information
+- No player group summaries (attackable counts, prayer usage, etc.)
+- No level-based PvP player indicators (highlighting attackable players or those within level range)
+- No spell targeting simplification (removing menu options to make targeting easier)
+
+## Menu Restrictions
+
+- No adding new menu entries that cause actions to be sent to the server
+- No menu modifications for Construction
+- No menu modifications for Blackjacking
+- No conditional menu entry removal based on NPC type, friend status, etc. (can be overpowered)
+
+## Interface Restrictions
+
+- No unhiding hidden interface components (special attack bar, minimap)
+- No moving or resizing click zones for 3D components
+- No moving or resizing click zones for combat options, inventory, equipment, or spellbook
+- No resizing prayer book click zones
+- No resizing spellbook components
+- No removing inventory pane background or making it click-through
+- No detached camera world interaction (interacting with the game world from a camera position that isn't the player's)
+
+## Input Restrictions
+
+- No injecting input events, including mouse and keyboard events
+- No autotyping — plugins must not programmatically insert text into the chatbox input (includes pasting, shorthand expansion)
+- No modifying outgoing chat messages after the user sends them
+
+## Data & Privacy Restrictions
+
+- No exposing player information over HTTP
+- No crowdsourcing data about other players (locations, gear, names, etc.)
+- No credential manager plugins that stores account credentials
+
+## Content Restrictions
+
+- No adult or overtly sexual content
+- No plugins that use player-provided IDs for their entire functionality (causes moderation issues)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ repositories {
 }
 
 def runeLiteVersion = 'latest.release'
+def pluginMainClass = 'com.timetomax.TimeToMaxPluginTest'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -27,17 +28,26 @@ dependencies {
 }
 
 group = 'com.timetomax'
-version = '1.1.3'
+version = '1.1.4'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'
 	options.release.set(11)
 }
 
+tasks.register('run', JavaExec) {
+	classpath = sourceSets.test.runtimeClasspath
+	mainClass = pluginMainClass
+
+	jvmArgs "-ea"
+	systemProperty 'timetomax.dev', 'true'
+	args "--developer-mode", "--debug"
+}
+
 tasks.register('shadowJar', Jar) {
 	dependsOn configurations.testRuntimeClasspath
 	manifest {
-		attributes('Main-Class': 'com.timetomax.TimeToMaxPluginTest', 'Multi-Release': true)
+		attributes('Main-Class': pluginMainClass, 'Multi-Release': true)
 	}
 
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE

--- a/dev-tools.md
+++ b/dev-tools.md
@@ -1,0 +1,32 @@
+# Time To Max — Dev Tools
+`build.gradle`'s `run` task now passes `-Dtimetomax.dev=true`. Dev commands are silently no-op without it, so production users never get access.
+
+## Dev panel label
+
+When dev mode is on, the panel shows a dev clock at the top of the target panel:
+
+```
+Dev clock: 2026-05-25 23:59:55 [+2d 12h]
+```
+
+- First half = effective wall time (`XpCalculator.now()` after offset).
+- Bracketed half = current offset, or `no offset` when real time.
+- Refreshes once per second from the existing `updateTargetPanel` tick.
+
+## Commands
+
+| Command | Effect |
+|---|---|
+| `::ttmreset` | Wipe state, re-initialize from current XP (already existed) |
+| `::ttmdate` | Print effective time + offset |
+| `::ttmdate +1d` | Jump forward 1 day; time keeps ticking from there |
+| `::ttmdate -6h` | Jump back 6 hours |
+| `::ttmdate +30m` / `::ttmdate +45s` | Minute/second shifts |
+| `::ttmdate +1d12h30m` | Combos — any chain of `\d+[dhms]` |
+| `::ttmdate 2026-05-30` | Jump to that date at 00:00:00 |
+| `::ttmdate 2026-05-30T23:59:55` | Jump to specific datetime (boundary tests) |
+| `::ttmdate clear` (or `off`, `reset`, `none`) | Zero the offset |
+| `::ttmstate` | Dump: effective time, offset, interval, ISO week, target/days remaining, current period start, earliest skill startDate, would-reset-now flag |
+| `::ttmgetstart` | Per-initialized-skill: startDate + startXp |
+
+Offset is process-local, not persisted — restart = clean slate.

--- a/src/main/java/com/timetomax/TimeToMaxPlugin.java
+++ b/src/main/java/com/timetomax/TimeToMaxPlugin.java
@@ -30,9 +30,16 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
 import java.awt.image.BufferedImage;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.IsoFields;
 import java.util.EnumSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Setter;
@@ -420,7 +427,8 @@ public class TimeToMaxPlugin extends Plugin
 		// Update the startDate for the skill if it isn't already set
 		if (xpState.getSkill(skill).getStartYear() == 9999)
 		{
-			xpState.getSkill(skill).updateStartDate(LocalDate.now().getDayOfMonth(), LocalDate.now().getMonthValue(),LocalDate.now().getYear());
+			LocalDate periodStart = XpCalculator.getCurrentPeriodStart(config.trackingInterval());
+			xpState.getSkill(skill).updateStartDate(periodStart.getDayOfMonth(), periodStart.getMonthValue(), periodStart.getYear());
 		}
 		
 		// Recalculate lowest skill flag after skill state update
@@ -457,7 +465,7 @@ public class TimeToMaxPlugin extends Plugin
 			{
 				log.debug("Loading xp state from save");
 				xpState.restore(save);
-				LocalDate now = LocalDate.now();
+				LocalDate periodStart = XpCalculator.getCurrentPeriodStart(config.trackingInterval());
 
 				for (Skill skill : save.skills.keySet())
 				{
@@ -468,7 +476,7 @@ public class TimeToMaxPlugin extends Plugin
 					skillState.updateGoals(startXp, goalXp);
 					if (xpState.getSkill(skill).getStartYear() == 9999)
 					{
-						xpState.getSkill(skill).updateStartDate(now.getDayOfMonth(), now.getMonthValue(),now.getYear());
+						xpState.getSkill(skill).updateStartDate(periodStart.getDayOfMonth(), periodStart.getMonthValue(), periodStart.getYear());
 					}
 				}
 
@@ -574,7 +582,8 @@ public class TimeToMaxPlugin extends Plugin
 
 		if (xpState.getSkill(skill).getStartYear() == 9999)
 		{
-			xpState.getSkill(skill).updateStartDate(LocalDate.now().getDayOfMonth(), LocalDate.now().getMonthValue(),LocalDate.now().getYear());
+			LocalDate periodStart = XpCalculator.getCurrentPeriodStart(config.trackingInterval());
+			xpState.getSkill(skill).updateStartDate(periodStart.getDayOfMonth(), periodStart.getMonthValue(), periodStart.getYear());
 		}
 
 		xpPanel.updateSkillExperience(true, xpPauseState.isPaused(skill),
@@ -625,11 +634,233 @@ public class TimeToMaxPlugin extends Plugin
 	@Subscribe
 	public void onCommandExecuted(CommandExecuted commandExecuted)
 	{
-		if (commandExecuted.getCommand().equals("ttmreset"))
+		String command = commandExecuted.getCommand();
+		if (command.equals("ttmreset"))
 		{
 			log.debug("TTM Reset command triggered by command");
 			handleTTMReset();
 			client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "TTM has been reset by user.", null);
+			return;
+		}
+
+		// Dev-only commands. Hidden from users; enable by launching the JVM with -Dtimetomax.dev=true.
+		if (!DEV_COMMANDS_ENABLED)
+		{
+			return;
+		}
+
+		String[] args = commandExecuted.getArguments();
+		switch (command)
+		{
+			case "ttmdate":
+				handleDevDateCommand(args);
+				break;
+			case "ttmstate":
+				handleDevStateCommand();
+				break;
+			case "ttmgetstart":
+				handleDevGetStartCommand();
+				break;
+		}
+	}
+
+	private static final boolean DEV_COMMANDS_ENABLED = Boolean.getBoolean("timetomax.dev");
+
+	private void devMessage(String message)
+	{
+		client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "[TTM dev] " + message, null);
+	}
+
+	private static final DateTimeFormatter DEV_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+	private static final Pattern DURATION_PART = Pattern.compile("(?i)(\\d+)([dhms])");
+
+	private void handleDevDateCommand(String[] args)
+	{
+		if (args == null || args.length == 0 || args[0].trim().equalsIgnoreCase("show"))
+		{
+			showEffectiveTime();
+			return;
+		}
+
+		String arg = args[0].trim();
+
+		if (arg.equalsIgnoreCase("clear") || arg.equalsIgnoreCase("off") || arg.equalsIgnoreCase("none") || arg.equalsIgnoreCase("reset"))
+		{
+			XpCalculator.clearTimeOffset();
+			showEffectiveTime();
+			return;
+		}
+
+		if (arg.startsWith("+") || arg.startsWith("-"))
+		{
+			boolean negative = arg.startsWith("-");
+			Duration delta = parseDurationSpec(arg.substring(1));
+			if (delta == null)
+			{
+				devMessage("Bad shift '" + arg + "'. Use e.g. +1d, -6h, +30m, +45s, or combos like +1d12h.");
+				return;
+			}
+			XpCalculator.shiftTime(negative ? delta.negated() : delta);
+			showEffectiveTime();
+			return;
+		}
+
+		try
+		{
+			LocalDateTime ldt = LocalDateTime.parse(arg);
+			XpCalculator.setOverrideTarget(ldt);
+			showEffectiveTime();
+			return;
+		}
+		catch (DateTimeParseException ignored)
+		{
+		}
+
+		try
+		{
+			LocalDate ld = LocalDate.parse(arg);
+			XpCalculator.setOverrideTarget(ld.atStartOfDay());
+			showEffectiveTime();
+			return;
+		}
+		catch (DateTimeParseException ignored)
+		{
+		}
+
+		devMessage("Bad arg '" + arg + "'. Try YYYY-MM-DD, YYYY-MM-DDTHH:MM, +1d, -6h, +30m, or 'clear'.");
+	}
+
+	private Duration parseDurationSpec(String spec)
+	{
+		if (spec == null || spec.isEmpty())
+		{
+			return null;
+		}
+		Matcher m = DURATION_PART.matcher(spec);
+		long totalSeconds = 0;
+		int matched = 0;
+		int end = 0;
+		while (m.find())
+		{
+			if (m.start() != end)
+			{
+				return null;
+			}
+			long v = Long.parseLong(m.group(1));
+			switch (m.group(2).toLowerCase())
+			{
+				case "d": totalSeconds += v * 86400L; break;
+				case "h": totalSeconds += v * 3600L; break;
+				case "m": totalSeconds += v * 60L; break;
+				case "s": totalSeconds += v; break;
+			}
+			matched++;
+			end = m.end();
+		}
+		if (matched == 0 || end != spec.length())
+		{
+			return null;
+		}
+		return Duration.ofSeconds(totalSeconds);
+	}
+
+	private void showEffectiveTime()
+	{
+		LocalDateTime now = XpCalculator.now();
+		Duration off = XpCalculator.getTimeOffset();
+		devMessage("Now: " + DEV_FMT.format(now) + (off.isZero() ? " (real)" : " (offset " + formatOffsetForChat(off) + ")"));
+	}
+
+	private static String formatOffsetForChat(Duration off)
+	{
+		long secs = off.getSeconds();
+		String sign = secs < 0 ? "-" : "+";
+		secs = Math.abs(secs);
+		long days = secs / 86400;
+		long hours = (secs % 86400) / 3600;
+		long minutes = (secs % 3600) / 60;
+		long seconds = secs % 60;
+		StringBuilder sb = new StringBuilder(sign);
+		if (days > 0) sb.append(days).append("d");
+		if (hours > 0) sb.append(hours).append("h");
+		if (minutes > 0) sb.append(minutes).append("m");
+		if (seconds > 0 || sb.length() == 1) sb.append(seconds).append("s");
+		return sb.toString();
+	}
+
+	private void handleDevStateCommand()
+	{
+		LocalDateTime nowDt = XpCalculator.now();
+		LocalDate now = nowDt.toLocalDate();
+		TrackingInterval interval = config.trackingInterval();
+		Duration off = XpCalculator.getTimeOffset();
+		devMessage("Now: " + DEV_FMT.format(nowDt) + (off.isZero() ? " (real)" : " (offset " + formatOffsetForChat(off) + ")"));
+		devMessage("Interval: " + interval
+			+ ", ISO week-year: " + now.get(IsoFields.WEEK_BASED_YEAR)
+			+ ", ISO week: " + now.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR));
+		devMessage("Target date: " + config.targetDate()
+			+ " (days remaining: " + ChronoUnit.DAYS.between(now, LocalDate.parse(config.targetDate())) + ")");
+		devMessage("Current period start (per fix): " + XpCalculator.getCurrentPeriodStart(interval));
+
+		LocalDate earliest = null;
+		int initialized = 0;
+		for (Skill skill : Skill.values())
+		{
+			XpStateSingle s = xpState.getSkillState(skill);
+			if (s == null || s.getStartXp() == -1)
+			{
+				continue;
+			}
+			initialized++;
+			LocalDate d = s.convertToLocalDate(s.getStartYear(), s.getStartMonth(), s.getStartDay());
+			if (earliest == null || d.isBefore(earliest))
+			{
+				earliest = d;
+			}
+		}
+		devMessage("Initialized skills: " + initialized + ", earliest startDate: " + (earliest != null ? earliest.toString() : "none"));
+
+		LocalDateTime nextBoundary = nextBoundaryAfter(nowDt, interval);
+		Duration until = Duration.between(nowDt, nextBoundary);
+		devMessage("Next reset boundary: " + DEV_FMT.format(nextBoundary) + " (in " + formatOffsetForChat(until) + ")");
+	}
+
+	/**
+	 * Wall-clock time of the next period boundary strictly after {@code from}.
+	 * WEEK = next Monday 00:00; MONTH = 1st of next month 00:00; DAY = tomorrow 00:00.
+	 */
+	private static LocalDateTime nextBoundaryAfter(LocalDateTime from, TrackingInterval interval)
+	{
+		LocalDate d = from.toLocalDate();
+		switch (interval)
+		{
+			case WEEK:
+				LocalDate nextMonday = d.with(java.time.DayOfWeek.MONDAY).plusWeeks(1);
+				return nextMonday.atStartOfDay();
+			case MONTH:
+				return d.withDayOfMonth(1).plusMonths(1).atStartOfDay();
+			default:
+				return d.plusDays(1).atStartOfDay();
+		}
+	}
+
+	private void handleDevGetStartCommand()
+	{
+		int shown = 0;
+		for (Skill skill : Skill.values())
+		{
+			XpStateSingle s = xpState.getSkillState(skill);
+			if (s == null || s.getStartXp() == -1)
+			{
+				continue;
+			}
+			LocalDate d = s.convertToLocalDate(s.getStartYear(), s.getStartMonth(), s.getStartDay());
+			devMessage(skill.getName() + ": startDate=" + d + ", startXp=" + s.getStartXp());
+			shown++;
+		}
+		if (shown == 0)
+		{
+			devMessage("No initialized skills.");
 		}
 	}
 
@@ -668,7 +899,8 @@ public class TimeToMaxPlugin extends Plugin
 
 			if (xpState.getSkill(skill).getStartYear() == 9999)
 			{
-				xpState.getSkill(skill).updateStartDate(LocalDate.now().getDayOfMonth(), LocalDate.now().getMonthValue(),LocalDate.now().getYear());
+				LocalDate periodStart = XpCalculator.getCurrentPeriodStart(config.trackingInterval());
+				xpState.getSkill(skill).updateStartDate(periodStart.getDayOfMonth(), periodStart.getMonthValue(), periodStart.getYear());
 			}
 
 			int startDay = xpState.getSkill(skill).getStartDay();

--- a/src/main/java/com/timetomax/XpCalculator.java
+++ b/src/main/java/com/timetomax/XpCalculator.java
@@ -1,7 +1,9 @@
 package com.timetomax;
 
+import java.time.DayOfWeek;
+import java.time.Duration;
 import java.time.LocalDate;
-import java.time.temporal.ChronoField;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.IsoFields;
 import java.util.HashMap;
@@ -20,6 +22,63 @@ public class XpCalculator
 	// Store starting XP for each skill for target tracking
 	private static final Map<Skill, LocalDate> intervalStartDates = new HashMap<>();
 
+	// Dev-only time offset. now()/today() return real time + this offset.
+	// Set via the ::ttmdate command (only active with -Dtimetomax.dev=true). Not persisted.
+	// Using an offset (instead of a frozen LocalDateTime) means time keeps ticking naturally
+	// from the override point, so the panel clock advances and boundary crossings happen live.
+	private static volatile Duration timeOffset = Duration.ZERO;
+
+	/**
+	 * Returns the current date-time, honoring the dev-only offset if one is set.
+	 * All interval / boundary / target-date logic should call this (or today()) instead of
+	 * LocalDate.now() / LocalDateTime.now() so the override takes effect end-to-end.
+	 */
+	public static LocalDateTime now()
+	{
+		Duration off = timeOffset;
+		return off.isZero() ? LocalDateTime.now() : LocalDateTime.now().plus(off);
+	}
+
+	public static LocalDate today()
+	{
+		return now().toLocalDate();
+	}
+
+	public static Duration getTimeOffset()
+	{
+		return timeOffset;
+	}
+
+	public static boolean isTimeOverridden()
+	{
+		return !timeOffset.isZero();
+	}
+
+	public static void clearTimeOffset()
+	{
+		timeOffset = Duration.ZERO;
+	}
+
+	/**
+	 * Shift the dev offset by the given delta. Positive jumps forward, negative jumps back.
+	 */
+	public static void shiftTime(Duration delta)
+	{
+		if (delta != null)
+		{
+			timeOffset = timeOffset.plus(delta);
+		}
+	}
+
+	/**
+	 * Set the offset such that now() returns the given target time. Real-time ticking continues
+	 * from that point (e.g., set to 23:59:50 to watch the clock cross midnight 10 seconds later).
+	 */
+	public static void setOverrideTarget(LocalDateTime target)
+	{
+		timeOffset = Duration.between(LocalDateTime.now(), target);
+	}
+
 	/**
 	 * Get the required XP per day to reach max level by the target date
 	 *
@@ -29,7 +88,7 @@ public class XpCalculator
 	 */
 	public static int getRequiredXpPerDay(int startXp, TimeToMaxConfig config)
 	{
-		long daysUntilTarget = ChronoUnit.DAYS.between(LocalDate.now(), LocalDate.parse(config.targetDate()));
+		long daysUntilTarget = ChronoUnit.DAYS.between(today(), LocalDate.parse(config.targetDate()));
 		if (daysUntilTarget <= 0)
 		{
 			if (config.maxSkillMode().equals(MaxSkillMode.NORMAL))
@@ -107,7 +166,7 @@ public class XpCalculator
 			return true;
 		}
 
-		LocalDate now = LocalDate.now();
+		LocalDate now = today();
 		switch (interval)
 		{
 			case DAY:
@@ -135,6 +194,29 @@ public class XpCalculator
 		return intervalStartDates.get(skill);
 	}
 
+	/**
+	 * Get the start date of the current period for the given interval, anchored to today.
+	 * Used so a reset that fires late (e.g. user wasn't logged in at the Monday boundary)
+	 * still anchors the new reference to the actual start of the ISO period, preventing
+	 * the reference date from drifting forward across consecutive missed boundaries.
+	 *
+	 * @param interval The tracking interval
+	 * @return The start of the current period (today for DAY, Monday for WEEK, 1st of month for MONTH)
+	 */
+	public static LocalDate getCurrentPeriodStart(TrackingInterval interval)
+	{
+		LocalDate now = today();
+		switch (interval)
+		{
+			case WEEK:
+				return now.with(DayOfWeek.MONDAY);
+			case MONTH:
+				return now.withDayOfMonth(1);
+			default:
+				return now;
+		}
+	}
+
 	public static LocalDate getMaxDateForLowestSkillWithOverride(int lowestSkillXp, TimeToMaxConfig config)
 	{
 		if (config.xpOverride())
@@ -153,9 +235,9 @@ public class XpCalculator
 			var daysUntilTarget = (long) Math.ceil((double) xpRequired / config.minimumXpOverride());
 			if (daysUntilTarget <= 0)
 			{
-				return LocalDate.now();
+				return today();
 			}
-			return LocalDate.now().plusDays(daysUntilTarget);
+			return today().plusDays(daysUntilTarget);
 		}
 		return null;
 	}

--- a/src/main/java/com/timetomax/XpPanel.java
+++ b/src/main/java/com/timetomax/XpPanel.java
@@ -80,6 +80,12 @@ class XpPanel extends PluginPanel
 	private final JLabel targetIntervalLabel = new JLabel(XpInfoBox.htmlLabel("Tracking: ", ""));
 	private final JLabel intervalsRemainingLabel = new JLabel(XpInfoBox.htmlLabel("Intervals remaining: ", ""));
 	private final JLabel xpOverrideLabel = new JLabel(XpInfoBox.htmlLabel("Daily Xp: ", ""));
+	// Dev-only label showing the effective wall clock (real or overridden). Only added to the
+	// panel when -Dtimetomax.dev=true was passed to the JVM.
+	private final JLabel devTimeLabel = new JLabel();
+	private static final boolean DEV_MODE = Boolean.getBoolean("timetomax.dev");
+	private static final java.time.format.DateTimeFormatter DEV_TIME_FORMAT =
+		java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 	// Configuration controls panel
 	private final JPanel configPanel = new JPanel();
 	private final JPanel configHeaderPanel = new JPanel();
@@ -287,7 +293,14 @@ class XpPanel extends PluginPanel
 		targetDateLabel.setFont(FontManager.getRunescapeSmallFont());
 		targetIntervalLabel.setFont(FontManager.getRunescapeSmallFont());
 		intervalsRemainingLabel.setFont(FontManager.getRunescapeSmallFont());
+		devTimeLabel.setFont(FontManager.getRunescapeSmallFont());
+		devTimeLabel.setForeground(java.awt.Color.ORANGE);
 
+		if (DEV_MODE)
+		{
+			targetPanel.setLayout(new GridLayout(5, 1));
+			targetPanel.add(devTimeLabel);
+		}
 		targetPanel.add(targetDateLabel);
 		targetPanel.add(targetIntervalLabel);
 		targetPanel.add(intervalsRemainingLabel);
@@ -371,6 +384,23 @@ class XpPanel extends PluginPanel
 		overallExpHour.setText(XpInfoBox.htmlLabel("Per hour: ", xpSnapshotTotal.getXpPerHour()));
 	}
 
+	private static String formatOffset(Duration off)
+	{
+		long secs = off.getSeconds();
+		String sign = secs < 0 ? "-" : "+";
+		secs = Math.abs(secs);
+		long days = secs / 86400;
+		long hours = (secs % 86400) / 3600;
+		long minutes = (secs % 3600) / 60;
+		long seconds = secs % 60;
+		StringBuilder sb = new StringBuilder(sign);
+		if (days > 0) sb.append(days).append("d");
+		if (hours > 0) sb.append(hours).append("h");
+		if (minutes > 0) sb.append(minutes).append("m");
+		if (seconds > 0 || sb.length() == 1) sb.append(seconds).append("s");
+		return sb.toString();
+	}
+
 	/**
 	 * Updates the target panel with the current configuration values
 	 */
@@ -380,15 +410,22 @@ class XpPanel extends PluginPanel
 		{
 			LocalDate targetDate = null;
 			TrackingInterval interval = config.trackingInterval();
-			LocalDate now = LocalDate.now();
+			LocalDate now = XpCalculator.today();
 
 			long intervalsRemaining;
 			String timeLeftInCurrentInterval;
 			String intervalUnit;
 			String currentIntervalLabel;
 
-			LocalDateTime currentTime = LocalDateTime.now();
+			LocalDateTime currentTime = XpCalculator.now();
 			LocalDateTime nextIntervalEnd;
+
+			if (DEV_MODE)
+			{
+				Duration off = XpCalculator.getTimeOffset();
+				String offText = off.isZero() ? "no offset" : formatOffset(off);
+				devTimeLabel.setText(XpInfoBox.htmlLabel("Dev clock: ", DEV_TIME_FORMAT.format(currentTime) + " [" + offText + "]"));
+			}
 
 			if (config.xpOverride())
 			{
@@ -479,6 +516,11 @@ class XpPanel extends PluginPanel
 			timeLeftLabel.setFont(FontManager.getRunescapeSmallFont());
 
 			targetPanel.removeAll();
+			if (DEV_MODE)
+			{
+				targetPanel.setLayout(new GridLayout(5, 1));
+				targetPanel.add(devTimeLabel);
+			}
 			targetPanel.add(targetDateLabel);
 			targetPanel.add(targetIntervalLabel);
 			targetPanel.add(intervalsRemainingLabel);


### PR DESCRIPTION
- Anchor reset startDate to Monday of ISO week / 1st of month so missed midnight boundaries don't drift the cycle forward
- Add XpCalculator.now()/today() backed by a Duration offset, gated by -Dtimetomax.dev=true
- Add ::ttmdate (jump by +1d/+6h/+30m or absolute datetime), ::ttmstate, ::ttmgetstart commands
- Show orange "Dev clock" label on panel when dev mode is on